### PR TITLE
"Added windows support"

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 const fs = require('fs');
 const path = require('path');
 const { extendConfig } = require('hardhat/config');
-
-const {
-  TASK_COMPILE,
-} = require('hardhat/builtin-tasks/task-names');
+const rimraf = require('rimraf');
+const { TASK_COMPILE } = require('hardhat/builtin-tasks/task-names');
 
 extendConfig(function (config, userConfig) {
   config.dependencyCompiler = Object.assign(
@@ -19,12 +17,12 @@ const generate = function (dependency) {
   return `
   // SPDX-License-Identifier: UNLICENSED
   pragma solidity *;
-  import '${ dependency }';
+  import '${dependency}';
   `;
 };
 
 task(TASK_COMPILE, async function (args, hre, runSuper) {
-  const directory = `${ hre.config.paths.sources }/_hardhat-dependency-compiler`;
+  const directory = `${hre.config.paths.sources}/_hardhat-dependency-compiler`;
 
   if (fs.existsSync(directory)) {
     throw 'hardhat-dependency-compiler: temporary source directory must not exist';
@@ -45,6 +43,11 @@ task(TASK_COMPILE, async function (args, hre, runSuper) {
   try {
     await runSuper();
   } finally {
-    fs.rmdirSync(directory, { recursive: true });
+    await rimraf(directory, function (err) {
+      if (err) {
+        throw err;
+      }
+      // done
+    });
   }
 });

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   "devDependencies": {
     "eslint": "^7.0.0",
     "hardhat": "^2.0.0"
+  },
+  "dependencies": {
+    "rimraf": "^3.0.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2196,6 +2196,13 @@ rimraf@^2.2.8:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"


### PR DESCRIPTION
The current version does not work on windows systems due to rm -rf {Recursive} not working in PowerShell 6.0.2

This change moves to a wrapper for recursive deletion, rimraf.